### PR TITLE
Fix leaking through of options as attributes.

### DIFF
--- a/Test/Case/View/Helper/SocialShareHelperTest.php
+++ b/Test/Case/View/Helper/SocialShareHelperTest.php
@@ -111,6 +111,19 @@ class SocialShareHelperTest extends CakeTestCase {
 				)
 			)
 		);
+
+		// Custom Text test
+		$expected = '<a href="whatsapp://send?text=Demo+Text+test%20http%3A%2F%2Fexample.com" target="_blank"><i class="fa fa-whatsapp"></i></a>';
+		$this->assertEquals(
+			$expected,
+			$this->SocialShare->fa(
+				'whatsapp',
+				'http://example.com',
+				array(
+					'text' => 'Demo Text test'
+				)
+			)
+		);
 	}
 
 }

--- a/View/Helper/SocialShareHelper.php
+++ b/View/Helper/SocialShareHelper.php
@@ -165,10 +165,14 @@ class SocialShareHelper extends AppHelper {
 		}
 		unset($options['icon_class']);
 
+		$attributes = $options;
+		unset($attributes['text']);
+		unset($attributes['image']);
+		
 		return $this->Html->link(
 			'<i class="' . $class . '"></i>',
 			$this->href($service, $url, $options),
-			$options
+			$attributes
 		);
 	}
 


### PR DESCRIPTION
We dont want `text="Demo Text test"` in

```
<a href="whatsapp://..." target="_blank" text="Demo Text test"><i class="fa fa-whatsapp"></i></a>
```
